### PR TITLE
feat: add stateless config values and handle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -68,5 +68,9 @@
   "trustedDependencies": ["c-kzg"],
   "simple-git-hooks": {
     "pre-commit": "bun run format && bun run lint:fix"
+  },
+  "dependencies": {
+    "@types/sshpk": "^1.17.4",
+    "sshpk": "^1.18.0"
   }
 }

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -50,6 +50,9 @@ export type HttpTransportConfig = {
   retryDelay?: TransportConfig['retryDelay'] | undefined
   /** The timeout (in ms) for the HTTP request. Default: 10_000 */
   timeout?: TransportConfig['timeout'] | undefined
+  /** statless config */
+  minimumRequiredAttestations?: HttpRpcClientOptions['minimumRequiredAttestations'] | undefined
+	identities?: HttpRpcClientOptions['identities'] | undefined
 }
 
 export type HttpTransport = Transport<
@@ -81,6 +84,8 @@ export function http(
     onFetchRequest,
     onFetchResponse,
     retryDelay,
+    minimumRequiredAttestations,
+    identities,
   } = config
   return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
     const { batchSize = 1000, wait = 0 } =
@@ -95,6 +100,8 @@ export function http(
       onRequest: onFetchRequest,
       onResponse: onFetchResponse,
       timeout,
+      minimumRequiredAttestations,
+      identities,
     })
 
     return createTransport(

--- a/src/utils/rpc/stateless.ts
+++ b/src/utils/rpc/stateless.ts
@@ -1,0 +1,198 @@
+import * as crypto from "crypto";
+import * as sshpk from "sshpk";
+import * as nacl from "tweetnacl";
+
+/**
+ * An attestation consists of the signature of the attester and cryptographic proof
+ */
+export type Attestation = {
+    /**
+     * The signature of the attester
+     */
+    signature: string;
+
+    /**
+     * The signature format (i.e. "ssh-ed25519")
+     */
+    signatureFormat: string;
+
+    /**
+     * The hashing algorithm used to hash the data (i.e. "sha256")
+     */
+    hashAlgo: string;
+
+    /**
+     * The hashed message data
+     */
+    msg: string;
+
+    /**
+     * The identifier of the attester
+     */
+    identity: string;
+};
+
+/**
+*  A JSON-RPC result, which are returned on success from a JSON-RPC server.
+*/
+export type AttestedJsonRpcResult =  {
+     /**
+     *  The response ID to match it to the relevant request.
+     */
+     id: number;
+
+     /**
+      *  The response result.
+      */
+     result: any;
+    /**
+     * Attestation data for the request.
+     */
+    attestations: Array<Attestation>;
+};
+
+export async function handleAndBlockNumberReqs(resp: any): Promise<any> {
+  if (!Array.isArray(resp)) {
+    resp = await handleResp(resp)
+  }
+
+  for (let i = 0; i < resp.length; i++) {
+    resp[i] = await handleResp(resp[i])
+  }
+
+  return resp
+}
+
+async function handleResp(response: AttestedJsonRpcResult): Promise<AttestedJsonRpcResult> {
+  let change: boolean = false;
+  let resultToChange: any;
+  if (response.result instanceof Object && Object.keys(response.result).length == 2) {
+    for (const [key, value] of Object.entries(response.result)) {
+      if (key == 'blockNumber') {
+        change = true
+      } else {
+        resultToChange = value
+      }
+    }
+  }
+
+  if (change) {
+    response.result = resultToChange
+  }
+
+  return response
+}
+
+export async function handleAttestations(resp: any, minimumRequiredAttestations: number = 1,
+  identities?: string[]): Promise<void> {
+    // If the response is not an array, convert it to an array
+    if (!Array.isArray(resp)) {
+        resp = [resp];
+    }
+ 
+    // Loop through each result in the response array
+    for (let i = 0; i < resp.length; i++) {
+        const result = resp[i];
+ 
+        // Verify the attested JSON-RPC response
+        const isValid = await verifyAttestedJsonRpcResponse(
+            result,
+            minimumRequiredAttestations,
+            identities
+        );
+ 
+        // If the response does not meet the attestation threshold, throw an error
+        if (!isValid) {
+            throw new Error(`Request did not meet the attestation threshold of ${minimumRequiredAttestations}.`);
+        }
+    }
+};
+
+async function verifyAttestedJsonRpcResponse(
+    response: AttestedJsonRpcResult,
+    minimumRequiredAttestations: number = 1,
+    identities?: string[]
+  ): Promise<boolean> {
+    // Generate hash of the response result
+    const resultBytes = Buffer.from(JSON.stringify(response.result));
+    const hash = crypto.createHash("sha256").update(resultBytes).digest();
+
+    const validAttestations: Attestation[] = [];
+
+
+    for (let i = 0; i < response.attestations.length; i++) {
+      const attestation = response.attestations[i];
+      // There's a chance the attestation does not have an identity if it's a batch response
+      // In that case, use the provided identities
+      if (identities && !attestation.identity) {
+        attestation.identity = identities[i];
+      }
+
+      // If identities are provided, only use attestations from those identities
+      if (identities && !identities.includes(attestation.identity)) {
+        continue;
+      }
+
+      const sshPublicKeyStr = await publicKeyFromIdentity(attestation.identity);
+      const key = sshpk.parseKey(sshPublicKeyStr, "ssh");
+
+      if (key.type !== "ed25519") {
+        throw new Error("The provided key is not an ed25519 key");
+      }
+      // @ts-ignore
+      const publicKeyUint8Array = new Uint8Array(key.part.A.data);
+
+      if (!verifyAttestation(attestation, publicKeyUint8Array, hash)) {
+        continue;
+      }
+
+      validAttestations.push(attestation);
+    }
+
+    // Count the number of attestations for each message
+    const msgCounts: { [key: string]: number } = {};
+    for (const attestation of validAttestations) {
+      msgCounts[attestation.msg] = (msgCounts[attestation.msg] || 0) + 1;
+    }
+
+    // Determine if consensus threshold is met
+    return Object.values(msgCounts).some(
+      (count) => count >= minimumRequiredAttestations
+    );
+}
+
+async function publicKeyFromIdentity(identity: string): Promise<string> {
+  const url = `${identity}/.well-known/stateless-key`;
+
+  try {
+      // Fetch data from the URL
+      const response = await fetch(url);
+
+      // Check if the response is successful (status code 2xx)
+      if (!response.ok) {
+          throw new Error(`Could not fetch public key from ${url}. Status code: ${response.status}`);
+      }
+
+      // Read and return the response body as text
+      return await response.text();
+  } catch (error) {
+      // Handle any errors that occur during the fetch operation
+      throw new Error(`Error fetching public key from ${url}: ${(error as Error).message}`);
+  }
+}
+
+function verifyAttestation(
+  attestation: Attestation,
+  publicKey: Uint8Array,
+  hash: Buffer
+): boolean {
+  const signatureBytes = Buffer.from(attestation.signature, "hex");
+  const signatureUint8Array = new Uint8Array(signatureBytes);
+
+  return nacl.sign.detached.verify(
+    new Uint8Array(hash),
+    signatureUint8Array,
+    publicKey
+  );
+}
+ 


### PR DESCRIPTION
Adds stateless special case config values for attestations and handle of andBlockNumber requests.

Example of usage of the new constructor:

```
    const config: HttpTransportConfig = {
      minimumRequiredAttestations: 1,
      identities: ['https://mock.identity.com']
    };

    const client = createPublicClient({
      chain: mainnet,
      transport: http('https://api.mock/ethereum/v1', config),
    });
```